### PR TITLE
[DM-9479] Create a Terraform deployment for RabbitMQ.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+sudo: false
+dist: trusty
+env:
+  global:
+    TERRAFORM_VERSION: "0.8.7"
+
+install:
+- mkdir bin
+- curl -o ./bin/terraform.zip "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip"
+- unzip -d ./bin ./bin/terraform.zip
+- chmod +x ./bin/terraform
+
+script:
+- ./bin/terraform validate

--- a/README.md
+++ b/README.md
@@ -1,2 +1,23 @@
-# terraform-rabbitmq
-Use Terraform to configure RabbitMQ.
+terraform-rabbitmq
+==================
+
+[![Build Status](https://travis-ci.org/lsst-sqre/terraform-rabbitmq.svg?branch=master)](https://travis-ci.org/lsst-sqre/terraform-rabbitmq)
+
+Use [Terraform](https://www.terraform.io/) to configure infrastructure for [RabbitMQ](https://www.rabbitmq.com/).
+
+This terraform deployment will create Ubuntu 16.04 instances in LSST's Nebula project. Next it will use [Amazon Route 53](https://aws.amazon.com/route53/) to create DNS entries for those instances.
+
+Use
+---
+
+   terraform apply
+
+Variables
+---------
+
+`count` *(default 3)* Create count many rabbit instances for the rabbit cluster.
+
+License
+-------
+
+See the [LICENSE file](https://github.com/lsst-sqre/terraform-rabbitmq/blob/master/LICENSE).

--- a/cloud-config.yaml
+++ b/cloud-config.yaml
@@ -1,0 +1,4 @@
+#cloud-config
+system_info:
+  default_user:
+    name: vagrant

--- a/rabbitmq-cluster.tf
+++ b/rabbitmq-cluster.tf
@@ -1,0 +1,32 @@
+# Use Nebula.
+provider "openstack" {
+}
+
+# Ensure the rabbit_lsst keypair is imported to OpenStack.
+resource "openstack_compute_keypair_v2" "rabbit_lsst-keypair" {
+  name = "rabbit_lsst"
+  public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCkVJJH7jBXvdnE+YE+4twX7Zi994duvZPu8JyGpduxEMVum3NwQy7XR+RArNtiMyxlNHw6dt9lifRNAPdnuqo/z+xcSsn1Gu8t3JDeL8SE4iFKg+S0gDLpYFLzT8wjt1nPe47qMfcHJaJ/WHvR0fRsLrUzrzUV0N2gmDhTN9wId0Xz9ZoTFtlCi8stYvYTGL42Fc1cwmjd/gfGzWJPU3/VNuW/oM/eezQCfyz0K8cp7BmBWkQjTdn82ARFzdUk26lFjM7wG5pX3wbceqO4vQOzYnWTS/BlQ7sflBD6VSlWZjuSTINlJX5fSkue0Tnc+xNXgOp3s9SQbhoRj4TrNJr6Hn7X4JLGpeb+Y/HRUIpbq8yWsXfj6sPl95YNdAbDww2EiGanUi7JfQt1ws0XcHbGxVDkOEN6bYW/4BWBEmjYyxB1d0JCr+ZZ9meZL461gaFgrJnlgKAzxnXPRksPjVps/Ih+CVsS1WCZaKokjboGXp1u5JdW54j+8GQyMoxB9pBlmXXGSYfIDdVXehF/GKsJvWoNZKvE5p47jlkY3lRUqAzHtTDcNXnfwDZkrW3ib6ILvmfzptDQbOPzuccKkFYXbTuJux3dkKNWJbE3VOjIDv1OcHr2yNv1EYE3kuC9P9q9jgjszwa9dfZz4gtq4bMeZuW1814f4BkyoaqHpT+llw== jmatt@lsst.org"
+}
+
+# Use Nebula's ext_net to get a public floating ip.
+resource "openstack_compute_floatingip_v2" "ext" {
+  count = "${var.count}"
+  pool = "ext-net"
+}
+
+# RabbitMQ Nebula Cluster.
+resource "openstack_compute_instance_v2" "rabbit_instances" {
+  count = "${var.count}"
+  name = "rabbit-${count.index}"
+  image_id = "e5607bd7-434d-4bf5-91ad-82b689b7c03e"
+  flavor_name = "m4.large"
+  key_pair = "rabbit_lsst"
+  security_groups = ["default", "remote SSH", "remote mosh", "remote https"]
+
+  user_data = "${file("cloud-config.yaml")}"
+  network {
+    name = "panopticon-network"
+    access_network = true
+    floating_ip = "${element(openstack_compute_floatingip_v2.ext.*.address, count.index)}"
+  }
+}

--- a/route53.tf
+++ b/route53.tf
@@ -1,0 +1,23 @@
+# Use aws.
+provider "aws" {
+  region = "us-west-2"
+}
+
+# Add rabbit.lsst.codes to rabbit-0.lsst.codes
+resource "aws_route53_record" "rabbit_route53" {
+  zone_id = "Z3TH0HRSNU67AM"
+  name = "rabbit.lsst.codes"
+  type = "A"
+  ttl = "300"
+  records = ["${openstack_compute_instance_v2.rabbit_instances.0.access_ip_v4}"]
+}
+
+# Add rabbit-#.lsst.codes
+resource "aws_route53_record" "rabbit_numbered_route53" {
+  count = "${var.count}"
+  zone_id = "Z3TH0HRSNU67AM"
+  name = "rabbit-${count.index}.lsst.codes"
+  type = "A"
+  ttl = "300"
+  records = ["${element(openstack_compute_instance_v2.rabbit_instances.*.access_ip_v4, count.index)}"]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,13 @@
+# Servers in cluster.
+variable "count" {
+  default = 3
+}
+
+data "terraform_remote_state" "s3-panopticon-rabbit-terraform-state" {
+    backend = "s3"
+    config {
+        bucket = "panopticon-rabbit-terraform-state"
+        key = "network/terraform.tfstate"
+        region = "us-west-2"
+    }
+}


### PR DESCRIPTION
Create a Terraform deployment for RabbitMQ.

  * Deploy cluster to Nebula (OpenStack).
  * Configure DNS using Amazon Route 53.
  * Use TravisCI to validate the Terraform configuration.

	new file:   .travis.yml
	modified:   README.md
	new file:   cloud-config.yaml
	new file:   rabbitmq-cluster.tf
	new file:   route53.tf
	new file:   variables.tf